### PR TITLE
Add smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ This project aims to provide a local AI agent based on [Open Interpreter](https:
    ```bash
    pip install -r requirements.txt
    ```
+3. Verify the installation by running the smoke test:
+   ```bash
+   python test_smoke.py
+   ```
 
 ## Temporary Patch for `Anthropic.__init__`
 Until the upstream `Anthropic` class is updated, apply the patch provided in this repository to allow initialization without API keys when running offline. When online, ensure your `ANTHROPIC_API_KEY` environment variable is set before starting the agent.

--- a/test_smoke.py
+++ b/test_smoke.py
@@ -1,0 +1,3 @@
+import openinterpreter
+
+openinterpreter.OpenInterpreter().run('print("hello")')


### PR DESCRIPTION
## Summary
- add a simple test_smoke.py that tries to import `openinterpreter`
- guide users to run the new smoke test in the README

## Testing
- `python -m pip install -r requirements.txt`
- `python test_smoke.py` *(fails: ModuleNotFoundError: No module named 'openinterpreter')*

------
https://chatgpt.com/codex/tasks/task_e_68424b2f63488321ab6cb4446f9083bf