### PR TITLE
Document OFFLINE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ This project aims to provide a local AI agent based on [Open Interpreter](https:
    python test_smoke.py
    ```
 
+## Configuration
+The agent reads a few environment variables when starting up:
+
+- `OFFLINE` – controls whether only local models are used. It defaults to
+  `true`, so the agent runs completely offline unless you explicitly set it to a
+  falsey value.
+- `ANTHROPIC_API_KEY` – when this variable is set, Open Interpreter can access
+  Anthropics models online. Provide a valid key and set `OFFLINE=false` if you
+  want to use cloud models.
+
 ## Temporary Patch for `Anthropic.__init__`
 This repository includes a `sitecustomize.py` file that monkey‑patches
 `Anthropic.__init__` to ignore the deprecated `proxies` parameter. Python will


### PR DESCRIPTION
## Summary
- document OFFLINE env var
- document ANTHROPIC_API_KEY usage

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openinterpreter')*

------
https://chatgpt.com/codex/tasks/task_e_68424f1e6aac8321bc56dd011cb38db7