### PR TITLE
Add offline test in smoke script

### DIFF
--- a/test_smoke.py
+++ b/test_smoke.py
@@ -1,3 +1,14 @@
-import openinterpreter
+try:
+    import openinterpreter  # type: ignore
+except ModuleNotFoundError:
+    import interpreter as openinterpreter
 
-openinterpreter.OpenInterpreter().run('print("hello")')
+exit_code = 0
+
+try:
+    openinterpreter.OpenInterpreter().run('print("hello")')
+    openinterpreter.OpenInterpreter().run("2+2", offline=True)
+except Exception:
+    exit_code = 1
+
+raise SystemExit(exit_code)


### PR DESCRIPTION
## Summary
- extend test to check running with offline mode
- make test return exit code 0 only if both commands succeed
- fall back to `interpreter` if `openinterpreter` module is missing

## Testing
- `python test_smoke.py; echo $?` *(fails: ModuleNotFoundError / offline run issues)*

------
https://chatgpt.com/codex/tasks/task_e_68424f206488832190a5c0c214d636e7