### PR TITLE
Add CI workflow and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/python:0-3.11

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "name": "AIA Devcontainer",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "forwardPorts": [7860]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt
+      - name: Run smoke tests
+        run: |
+          python test_smoke.py


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install requirements and run smoke test
- add Codespaces devcontainer with Python 3.11 and forwarded port 7860

## Testing
- `python -m pip install -r requirements.txt`
- `python test_smoke.py` *(fails: ModuleNotFoundError: No module named 'openinterpreter')*

------
https://chatgpt.com/codex/tasks/task_e_68424f21bc9c83218f003e866116a99c