### PR TITLE
Add argparse options for offline and model

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ After activating the virtual environment and installing requirements, start the 
 ```bash
 python main.py
 ```
+You can override the model or offline mode from the command line. For example:
+```bash
+python main.py --model ollama/phi3:mini
+```
+Pass `--offline` to force local-only mode regardless of the `OFFLINE` environment variable.
 On Windows, you can use the provided batch script which activates the
 virtual environment and launches the agent:
 ```bat

--- a/main.py
+++ b/main.py
@@ -1,13 +1,34 @@
 import os
+import argparse
 from interpreter import interpreter
 from interpreter.terminal_interface.start_terminal_interface import start_terminal_interface
 
 
-def configure_interpreter() -> None:
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run Open Interpreter")
+    parser.add_argument(
+        "--offline",
+        help="Override OFFLINE environment variable (true/false)",
+    )
+    parser.add_argument(
+        "--model",
+        help="Specify model identifier (overrides MODEL environment variable)",
+    )
+    return parser.parse_args()
+
+
+def configure_interpreter(args: argparse.Namespace) -> None:
     """Configure the default Open Interpreter instance."""
     # Determine offline mode (default True)
     offline_env = os.getenv("OFFLINE", "true")
-    interpreter.offline = offline_env.lower() in {"1", "true", "yes"}
+    offline_value = args.offline if args.offline is not None else offline_env
+    interpreter.offline = str(offline_value).lower() in {"1", "true", "yes"}
+
+    # Determine model (from CLI, env var, or default Ollama model)
+    model = args.model if args.model is not None else os.getenv("MODEL")
+    if model:
+        interpreter.llm.model = model
 
     # If running offline and no model selected, default to an Ollama model
     if interpreter.offline and not interpreter.llm.model:
@@ -22,7 +43,8 @@ def configure_interpreter() -> None:
 
 
 def main() -> None:
-    configure_interpreter()
+    args = parse_args()
+    configure_interpreter(args)
     start_terminal_interface(interpreter)
 
 


### PR DESCRIPTION
## Summary
- add argparse CLI flags `--offline` and `--model`
- document example `python main.py --model ollama/phi3:mini` in README

## Testing
- `python test_smoke.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68425327bbc48321ba3509eda4876f5e