### PR TITLE
Clean README and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,43 +19,23 @@ This project aims to provide a local AI agent based on [Open Interpreter](https:
    ```
 2. Activate the virtual environment:
    ```bash
-hg676y-codex/implement-script-for-venv-setup
    source .venv/bin/activate  # on Windows use .venv\Scripts\activate
    ```
 3. Copy `.env.example` to `.env` and add your `ANTHROPIC_API_KEY` if needed:
    ```bash
    cp .env.example .env
    ```
-=======
-   pip install -r requirements.txt
-3. Copy `.env.example` to `.env` and add your `ANTHROPIC_API_KEY` if needed:
-   ```bash
-   cp .env.example .env
-   ```
- tmnpki-codex/show-agent-start-with-offline=true-and-local-model
-=======
-main
- main
 4. Verify the installation by running the smoke test:
    ```bash
    python test_smoke.py
    ```
 
 ## Configuration
-The agent reads a few environment variables when starting up:
+- The agent reads a few environment variables when starting up:
 
 - `OFFLINE` – controls whether only local models are used. It defaults to
- tmnpki-codex/show-agent-start-with-offline=true-and-local-model
   `true`, so the agent runs completely offline unless you explicitly set it to a
   falsey value.
-=======
- hg676y-codex/implement-script-for-venv-setup
-  `true`, so the agent runs completely offline unless you explicitly set it to a falsey value.
-=======
-  `true`, so the agent runs completely offline unless you explicitly set it to a
-  falsey value.
- main
- main
 - `ANTHROPIC_API_KEY` – when this variable is set, Open Interpreter can access
   Anthropics models online. Provide a valid key and set `OFFLINE=false` if you
   want to use cloud models.

--- a/main.py
+++ b/main.py
@@ -1,17 +1,7 @@
 import os
- tmnpki-codex/show-agent-start-with-offline=true-and-local-model
 import argparse
-=======
-hg676y-codex/implement-script-for-venv-setup
-import argparse
-=======
-vq0ck5-codex/evaluate-pywinauto-or-uiautomation-for-automation
 import sys
 import types
-import argparse
-main
-main
- main
 from interpreter import interpreter
 from interpreter.terminal_interface.start_terminal_interface import start_terminal_interface
 
@@ -21,18 +11,9 @@ try:
     import interpreter.computer_use.tools.computer  # noqa: F401
 except Exception:  # pragma: no cover - only executed when pyautogui is missing
     from windows_computer_tool import ComputerTool as WinComputerTool
-
- tmnpki-codex/show-agent-start-with-offline=true-and-local-model
-=======
-hg676y-codex/implement-script-for-venv-setup
-=======
     module = types.ModuleType("interpreter.computer_use.tools.computer")
     module.ComputerTool = WinComputerTool
     sys.modules["interpreter.computer_use.tools.computer"] = module
-
-
-main
- main
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run Open Interpreter")

--- a/run_agent.bat
+++ b/run_agent.bat
@@ -1,5 +1,4 @@
 @echo off
- tmnpki-codex/show-agent-start-with-offline=true-and-local-model
 REM Quick start script for the AIA agent on Windows
 REM Set ANTHROPIC_API_KEY if you want to use online models
 REM Set OFFLINE=true to force local mode
@@ -9,10 +8,4 @@ if exist .venv\Scripts\activate (
     call .venv\Scripts\activate
 )
 
-=======
-REM Activate virtual environment and run the agent
-REM Set ANTHROPIC_API_KEY if you want to use online models
-REM Set OFFLINE=true to force local mode
-call .venv\Scripts\activate
- main
 python main.py

--- a/test_smoke.py
+++ b/test_smoke.py
@@ -1,4 +1,3 @@
- tmnpki-codex/show-agent-start-with-offline=true-and-local-model
 """Basic smoke test to verify that Open Interpreter imports correctly."""
 
 import os
@@ -11,41 +10,3 @@ from main import configure_interpreter
 
 configure_interpreter(Namespace(offline=None, model=None))
 interpreter.chat('print("hello")')
-=======
-hg676y-codex/implement-script-for-venv-setup
-"""Simple smoke test to verify Open Interpreter installation."""
-
-try:
-    from interpreter import interpreter
-except ModuleNotFoundError:
-    import openinterpreter as interpreter  # type: ignore
-
-# Smoke test: import the interpreter package and confirm the object exists.
-interpreter.offline = True
-assert hasattr(interpreter, "chat")
-print(f"Interpreter loaded. offline={interpreter.offline}")
-=======
-vq0ck5-codex/evaluate-pywinauto-or-uiautomation-for-automation
-import importlib.util
-
-# Basic sanity check that the interpreter package is installed.
-assert importlib.util.find_spec("interpreter") is not None
-print("interpreter module available")
-=======
-try:
-    import openinterpreter  # type: ignore
-except ModuleNotFoundError:
-    import interpreter as openinterpreter
-
-exit_code = 0
-
-try:
-    openinterpreter.OpenInterpreter().run('print("hello")')
-    openinterpreter.OpenInterpreter().run("2+2", offline=True)
-except Exception:
-    exit_code = 1
-
-raise SystemExit(exit_code)
-main
-main
- main


### PR DESCRIPTION
## Summary
- remove stray codex lines from docs and source
- fix setup instructions numbering
- clean up run script and smoke test

## Testing
- `pip install -r requirements.txt` *(fails: Could not find pywin32)*
- `python test_smoke.py` *(fails: ModuleNotFoundError: No module named 'interpreter')*

------
https://chatgpt.com/codex/tasks/task_e_6842593483408321817ffa62ac115435